### PR TITLE
chore: add npm metadata

### DIFF
--- a/.changes/config.json
+++ b/.changes/config.json
@@ -24,7 +24,14 @@
   "packages": {
     "@crabnebula/file-icons": {
       "path": ".",
-      "manager": "javascript"
+      "manager": "javascript",
+      "dependencies": [
+        "file-icons"
+      ]
+    },
+    "file-icons": {
+      "path": ".",
+      "manager": "rust"
     }
   }
 }

--- a/.changes/metadata.md
+++ b/.changes/metadata.md
@@ -1,0 +1,5 @@
+---
+"file-icons": patch
+---
+
+Update manifest metadata

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -33,8 +33,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 20
-          cache: 'pnpm'
-          cache-dependency-path: 'pnpm-lock.yaml'
       - name: Audit JS
         run: pnpm audit
       - name: Audit Rust

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,13 @@
 [package]
 name = "file-icons"
-authors = ["CrabNebula <hello@crabnebula.dev>"]
+authors = ["Jonas Kruckenberg <jonas@crabnebula.dev>", "CrabNebula <hello@crabnebula.dev>"]
 edition = "2021"
 version = "0.1.0"
 rust-version = "1.70.0"
 license = "MIT or Apache-2.0"
-repository = "https://github.com/crabnebula-dev/devtools"
+repository = "https://github.com/crabnebula-dev/file-icons"
+keywords = ["icons", "file-icons"]
+include = ["/src", "LICENSE-MIT.md", "LICENSE-APACHE.md", "/icons"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ rust-version = "1.70.0"
 license = "MIT or Apache-2.0"
 repository = "https://github.com/crabnebula-dev/file-icons"
 keywords = ["icons", "file-icons"]
-include = ["/src", "LICENSE-MIT.md", "LICENSE-APACHE.md", "/icons"]
+include = ["/src", "LICENSE-MIT.md", "LICENSE-APACHE.md", "/icons", "!*.ts", "!*.ts"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]

--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
     "icons",
     "file-icons"
   ],
+  "repository": "https://github.com/crabnebula-dev/file-icons",
+  "bugs": {
+    "url": "https://github.com/crabnebula-dev/file-icons/issues",
+  },
   "type": "module",
   "main": "dist/lib.js",
   "types": "dist/lib.d.ts",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "repository": "https://github.com/crabnebula-dev/file-icons",
   "bugs": {
-    "url": "https://github.com/crabnebula-dev/file-icons/issues",
+    "url": "https://github.com/crabnebula-dev/file-icons/issues"
   },
   "type": "module",
   "main": "dist/lib.js",


### PR DESCRIPTION
Adds metadata for npm & enables rust crate to be published